### PR TITLE
Update "root to:" syntax

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,5 @@ Messaging::Engine.routes.draw do
     end
   end
   post 'search' => 'messages#search'
-  root to: 'messages#index'
+  root :to => 'messages#index'
 end


### PR DESCRIPTION
Fixed the routes file to avoid this error on rails 3.2.2:

``` /usr/lib/ruby/gems/1.8/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:245:
in `load': ~/.bundler/ruby/1.8/rails-messaging-4d72e78e0c92/config/routes.rb:12:
syntax error, unexpected ':', expecting kEND (SyntaxError)
  root to: 'messages#index'
          ^
```
